### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -323,7 +323,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.update-repository.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v6
         # env:
         #   GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2024 The Linux Foundation <https://linuxfoundation.org>
-#
 # For most projects, this workflow file will not need changing; you simply need
 # to commit it to your repository.
 #


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit