### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2024 The Linux Foundation <https://linuxfoundation.org>
-#
 # For most projects, this workflow file will not need changing; you simply need
 # to commit it to your repository.
 #

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 'Setup PDM for build commands'
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@v4.1
 
       - name: 'Setup Python 3.10'
         uses: actions/setup-python@v5.2.0
@@ -157,7 +157,7 @@ jobs:
           rm dist/*.sig*
 
       - name: 'Setup PDM for build commands'
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@v3
 
       - name: 'Publish release to PyPI'
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit