### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -60,7 +60,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: "Setup PDM for build commands"
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@v4.1
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,4 @@
+---
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2024 The Linux Foundation <https://linuxfoundation.org>
 #

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -35,7 +35,7 @@ jobs:
           python-version: "3.11"
 
       - name: "Setup PDM for build commands"
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@v4.1
 
       - name: "Install dependencies"
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 'Setup PDM for build commands'
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@v4.1
 
       - name: 'Setup Python 3.10'
         uses: actions/setup-python@v5.2.0
@@ -157,7 +157,7 @@ jobs:
           rm dist/*.sig*
 
       - name: 'Setup PDM for build commands'
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@v4.1
 
       - name: 'Publish release to PyPI'
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -50,7 +50,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: "Setup PDM for build commands"
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@v4.1
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -32,7 +32,7 @@ jobs:
           python-version: ${{ env.python-version }}
 
       - name: "Setup PDM for build commands"
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@v4.1
         with:
           python-version: ${{ env.python-version }}
 

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -44,7 +44,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: "Setup PDM for build commands"
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@v4.1
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit