### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -36,7 +36,6 @@ jobs:
           #SHELLCODESTART
 
           set -euo pipefail
-          # set -x
 
           # Define variables
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ exclude: |
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # 5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -65,7 +65,7 @@ repos:
         args: ["-x"]  # Check external files
 
   - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
-    rev: v1.7.2.16
+    rev: v1.7.3.17
     hooks:
       - id: actionlint
 
@@ -78,7 +78,7 @@ repos:
           ignore-from-file: [.gitignore],}"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.8
+    rev: v0.6.9
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]
@@ -94,7 +94,7 @@ repos:
           then /bin/mkdir .mypy_cache; fi; exit 0'
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.11.2"
+    rev: v1.11.2
     hooks:
       - id: mypy
         verbose: true


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit