### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: "Parse: pyproject.toml"
         id: parse-project-metadata
         # yamllint disable-line rule:line-length
-        uses: os-climate/devops-reusable-workflows/.github/actions/python-versions-matrix@main
+        uses: os-climate/devops-toolkit/.github/actions/python-versions-matrix@main
 
   builds:
     name: "Python builds"
@@ -97,4 +97,4 @@ jobs:
         id: twine-check-artefacts
         env:
           package-path: ${{ env.package-path }}
-        uses: os-climate/devops-reusable-workflows/.github/actions/twine-check-artefacts@main
+        uses: os-climate/devops-toolkit/.github/actions/python-twine-check@main

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: "Populate environment variables"
         id: parse-project-metadata
         # yamllint disable-line rule:line-length
-        uses: os-climate/devops-reusable-workflows/.github/actions/python-versions-matrix@main
+        uses: os-climate/devops-toolkit/.github/actions/python-versions-matrix@main
 
   builds:
     name: "Python builds"

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: "Populate environment variables"
         id: parse-project-metadata
         # yamllint disable-line rule:line-length
-        uses: os-climate/devops-reusable-workflows/.github/actions/python-versions-matrix@main
+        uses: os-climate/devops-toolkit/.github/actions/python-versions-matrix@main
 
   testing:
     name: "Run unit tests"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ exclude: |
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # v5.0.0
+    rev: v5.0.0 # v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -78,7 +78,7 @@ repos:
           ignore-from-file: [.gitignore],}"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.7.0
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]
@@ -94,7 +94,7 @@ repos:
           then /bin/mkdir .mypy_cache; fi; exit 0'
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.12.1
     hooks:
       - id: mypy
         verbose: true


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit